### PR TITLE
feat(cli): add option to override existing files during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,21 @@ bunx open-workflows [OPTIONS]
 OPTIONS
   --skills       Install skills only
   --workflows    Install workflows only
+  --force, -f    Override existing files without prompts
   --version, -v  Display version
   --help, -h     Display help
+```
+
+### Override Behavior
+
+By default, the CLI will prompt you to confirm overriding each existing file. Use `--force` to skip prompts and override all existing files automatically.
+
+```bash
+# Override all existing files
+bunx open-workflows --force
+
+# Interactive mode - prompts for each existing file
+bunx open-workflows
 ```
 
 ## Plugin Installation

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -20,6 +20,29 @@ This interactive installer will:
 3. Install GitHub Actions to `.github/workflows/`
 4. Create/update `.opencode/opencode.json`
 
+### CLI Options
+
+```bash
+bunx open-workflows [OPTIONS]
+
+OPTIONS
+  --skills       Install skills only
+  --workflows    Install workflows only
+  --force, -f    Override existing files without prompts
+  --version, -v  Display version
+  --help, -h     Display help
+```
+
+By default, the CLI will prompt you to confirm overriding each existing file. Use `--force` to skip prompts and override all existing files automatically:
+
+```bash
+# Override all existing files
+bunx open-workflows --force
+
+# Interactive mode - prompts for each existing file
+bunx open-workflows
+```
+
 ## Manual Setup
 
 ### 1. Install the Plugin

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,17 @@
 
 import * as p from '@clack/prompts';
 import color from 'picocolors';
-import { installWorkflows, installSkills, installAuthWorkflow, createOpencodeConfig, type InstallResult } from './installer';
+import {
+  installWorkflows,
+  installSkills,
+  installAuthWorkflow,
+  createOpencodeConfig,
+  checkExistingWorkflows,
+  checkExistingSkills,
+  checkExistingAuthWorkflow,
+  type InstallResult,
+  type ExistingFile,
+} from './installer';
 import type { WorkflowType } from './templates';
 
 const pkg = await import('../../package.json').catch(() => ({ version: 'unknown' }));
@@ -13,6 +23,7 @@ const isHelp = args.includes('--help') || args.includes('-h');
 const isVersion = args.includes('--version') || args.includes('-v');
 const isSkillsOnly = args.includes('--skills');
 const isWorkflowsOnly = args.includes('--workflows');
+const isForce = args.includes('--force') || args.includes('-f');
 
 if (isVersion) {
   process.stdout.write(`@activade/open-workflows v${cliVersion}\n`);
@@ -30,6 +41,7 @@ USAGE
 OPTIONS
   --skills       Install skills only (no workflows)
   --workflows    Install workflows only (no skills)
+  --force, -f    Override existing files without prompts
   --version, -v  Display version
   --help, -h     Display this help
 
@@ -45,7 +57,7 @@ For more information: https://github.com/activadee/open-workflows
 
 p.intro(color.bgCyan(color.black(` @activade/open-workflows v${cliVersion} `)));
 
-const results = await p.group(
+const promptResults = await p.group(
   {
     workflows: () =>
       p.multiselect({
@@ -79,24 +91,81 @@ const results = await p.group(
   }
 );
 
+const selectedWorkflows = (promptResults.workflows || []) as WorkflowType[];
+const useOAuth = Boolean(promptResults.useOAuth);
+
+const skillOverrides = new Set<string>();
+const workflowOverrides = new Set<string>();
+let overrideAuth = false;
+
+if (!isForce) {
+  const existingFiles: ExistingFile[] = [];
+
+  if (!isWorkflowsOnly) {
+    existingFiles.push(...checkExistingSkills({}));
+  }
+
+  if (!isSkillsOnly) {
+    existingFiles.push(...checkExistingWorkflows({ workflows: selectedWorkflows }));
+    if (useOAuth) {
+      const authFile = checkExistingAuthWorkflow({});
+      if (authFile) {
+        existingFiles.push(authFile);
+      }
+    }
+  }
+
+  if (existingFiles.length > 0) {
+    p.log.warn(`Found ${existingFiles.length} existing file(s):`);
+
+    for (const file of existingFiles) {
+      const shouldOverride = await p.confirm({
+        message: `Override ${file.path}?`,
+        initialValue: false,
+      });
+
+      if (p.isCancel(shouldOverride)) {
+        p.cancel('Installation cancelled.');
+        process.exit(0);
+      }
+
+      if (shouldOverride) {
+        if (file.type === 'skill') {
+          skillOverrides.add(file.name);
+        } else if (file.type === 'workflow') {
+          workflowOverrides.add(file.name);
+        } else if (file.type === 'auth') {
+          overrideAuth = true;
+        }
+      }
+    }
+  }
+}
+
 const s = p.spinner();
 s.start('Installing open-workflows...');
 
 const allResults: InstallResult[] = [];
-const selectedWorkflows = (results.workflows || []) as WorkflowType[];
-const useOAuth = Boolean(results.useOAuth);
 
 if (!isWorkflowsOnly) {
-  const skillResults = installSkills({});
+  const skillResults = installSkills({
+    override: isForce,
+    overrideNames: isForce ? undefined : skillOverrides,
+  });
   allResults.push(...skillResults);
 }
 
 if (!isSkillsOnly) {
-  const workflowResults = installWorkflows({ workflows: selectedWorkflows, useOAuth });
+  const workflowResults = installWorkflows({
+    workflows: selectedWorkflows,
+    useOAuth,
+    override: isForce,
+    overrideNames: isForce ? undefined : workflowOverrides,
+  });
   allResults.push(...workflowResults);
 
   if (useOAuth) {
-    const authResult = installAuthWorkflow({});
+    const authResult = installAuthWorkflow({ override: isForce || overrideAuth });
     allResults.push(authResult);
   }
 }
@@ -114,6 +183,7 @@ const hasErrors = allResults.some((r) => r.status === 'error');
 s.stop(hasErrors ? 'Installation completed with errors' : 'Installation complete!');
 
 const created = allResults.filter((r) => r.status === 'created');
+const overwritten = allResults.filter((r) => r.status === 'overwritten');
 const skipped = allResults.filter((r) => r.status === 'skipped');
 const errors = allResults.filter((r) => r.status === 'error');
 
@@ -121,6 +191,13 @@ if (created.length > 0) {
   p.log.success(`Created ${created.length} file(s):`);
   for (const r of created) {
     p.log.message(`  ${color.green('✓')} ${r.path}`);
+  }
+}
+
+if (overwritten.length > 0) {
+  p.log.success(`Overwritten ${overwritten.length} file(s):`);
+  for (const r of overwritten) {
+    p.log.message(`  ${color.cyan('◆')} ${r.path}`);
   }
 }
 

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -1,0 +1,219 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  installWorkflows,
+  installSkills,
+  installAuthWorkflow,
+  checkExistingWorkflows,
+  checkExistingSkills,
+  checkExistingAuthWorkflow,
+} from '../src/cli/installer.ts';
+
+describe('installer override functionality', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'open-workflows-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('installWorkflows', () => {
+    it('creates new workflow files', () => {
+      const results = installWorkflows({
+        workflows: ['review'],
+        cwd: tempDir,
+        useOAuth: false,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('created');
+      expect(results[0].name).toBe('review');
+      expect(fs.existsSync(path.join(tempDir, '.github', 'workflows', 'pr-review.yml'))).toBe(true);
+    });
+
+    it('skips existing files without override', () => {
+      const workflowDir = path.join(tempDir, '.github', 'workflows');
+      fs.mkdirSync(workflowDir, { recursive: true });
+      fs.writeFileSync(path.join(workflowDir, 'pr-review.yml'), 'existing content');
+
+      const results = installWorkflows({
+        workflows: ['review'],
+        cwd: tempDir,
+        useOAuth: false,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('skipped');
+      expect(fs.readFileSync(path.join(workflowDir, 'pr-review.yml'), 'utf-8')).toBe('existing content');
+    });
+
+    it('overwrites existing files with override=true', () => {
+      const workflowDir = path.join(tempDir, '.github', 'workflows');
+      fs.mkdirSync(workflowDir, { recursive: true });
+      fs.writeFileSync(path.join(workflowDir, 'pr-review.yml'), 'existing content');
+
+      const results = installWorkflows({
+        workflows: ['review'],
+        cwd: tempDir,
+        useOAuth: false,
+        override: true,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('overwritten');
+      expect(fs.readFileSync(path.join(workflowDir, 'pr-review.yml'), 'utf-8')).not.toBe('existing content');
+    });
+
+    it('overwrites specific files with overrideNames', () => {
+      const workflowDir = path.join(tempDir, '.github', 'workflows');
+      fs.mkdirSync(workflowDir, { recursive: true });
+      fs.writeFileSync(path.join(workflowDir, 'pr-review.yml'), 'existing review');
+      fs.writeFileSync(path.join(workflowDir, 'issue-label.yml'), 'existing label');
+
+      const results = installWorkflows({
+        workflows: ['review', 'label'],
+        cwd: tempDir,
+        useOAuth: false,
+        overrideNames: new Set(['review']),
+      });
+
+      expect(results).toHaveLength(2);
+      
+      const reviewResult = results.find(r => r.name === 'review');
+      const labelResult = results.find(r => r.name === 'label');
+      
+      expect(reviewResult.status).toBe('overwritten');
+      expect(labelResult.status).toBe('skipped');
+    });
+  });
+
+  describe('installSkills', () => {
+    it('creates new skill files', () => {
+      const results = installSkills({ cwd: tempDir });
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every(r => r.status === 'created')).toBe(true);
+    });
+
+    it('skips existing files without override', () => {
+      const skillDir = path.join(tempDir, '.opencode', 'skill', 'pr-review');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'existing content');
+
+      const results = installSkills({ cwd: tempDir });
+
+      const prReviewResult = results.find(r => r.name === 'pr-review');
+      expect(prReviewResult.status).toBe('skipped');
+    });
+
+    it('overwrites existing files with override=true', () => {
+      const skillDir = path.join(tempDir, '.opencode', 'skill', 'pr-review');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'existing content');
+
+      const results = installSkills({ cwd: tempDir, override: true });
+
+      const prReviewResult = results.find(r => r.name === 'pr-review');
+      expect(prReviewResult.status).toBe('overwritten');
+    });
+
+    it('overwrites specific files with overrideNames', () => {
+      const skillDir1 = path.join(tempDir, '.opencode', 'skill', 'pr-review');
+      const skillDir2 = path.join(tempDir, '.opencode', 'skill', 'issue-label');
+      fs.mkdirSync(skillDir1, { recursive: true });
+      fs.mkdirSync(skillDir2, { recursive: true });
+      fs.writeFileSync(path.join(skillDir1, 'SKILL.md'), 'existing review');
+      fs.writeFileSync(path.join(skillDir2, 'SKILL.md'), 'existing label');
+
+      const results = installSkills({
+        cwd: tempDir,
+        overrideNames: new Set(['pr-review']),
+      });
+
+      const prReviewResult = results.find(r => r.name === 'pr-review');
+      const issueLabelResult = results.find(r => r.name === 'issue-label');
+      
+      expect(prReviewResult.status).toBe('overwritten');
+      expect(issueLabelResult.status).toBe('skipped');
+    });
+  });
+
+  describe('installAuthWorkflow', () => {
+    it('creates new auth workflow file', () => {
+      const result = installAuthWorkflow({ cwd: tempDir });
+
+      expect(result.status).toBe('created');
+      expect(fs.existsSync(path.join(tempDir, '.github', 'workflows', 'opencode-auth.yml'))).toBe(true);
+    });
+
+    it('skips existing file without override', () => {
+      const workflowDir = path.join(tempDir, '.github', 'workflows');
+      fs.mkdirSync(workflowDir, { recursive: true });
+      fs.writeFileSync(path.join(workflowDir, 'opencode-auth.yml'), 'existing content');
+
+      const result = installAuthWorkflow({ cwd: tempDir });
+
+      expect(result.status).toBe('skipped');
+      expect(fs.readFileSync(path.join(workflowDir, 'opencode-auth.yml'), 'utf-8')).toBe('existing content');
+    });
+
+    it('overwrites existing file with override=true', () => {
+      const workflowDir = path.join(tempDir, '.github', 'workflows');
+      fs.mkdirSync(workflowDir, { recursive: true });
+      fs.writeFileSync(path.join(workflowDir, 'opencode-auth.yml'), 'existing content');
+
+      const result = installAuthWorkflow({ cwd: tempDir, override: true });
+
+      expect(result.status).toBe('overwritten');
+      expect(fs.readFileSync(path.join(workflowDir, 'opencode-auth.yml'), 'utf-8')).not.toBe('existing content');
+    });
+  });
+
+  describe('checkExisting* functions', () => {
+    it('checkExistingWorkflows returns existing workflow files', () => {
+      const workflowDir = path.join(tempDir, '.github', 'workflows');
+      fs.mkdirSync(workflowDir, { recursive: true });
+      fs.writeFileSync(path.join(workflowDir, 'pr-review.yml'), 'content');
+
+      const existing = checkExistingWorkflows({ workflows: ['review', 'label'], cwd: tempDir });
+
+      expect(existing).toHaveLength(1);
+      expect(existing[0].name).toBe('review');
+      expect(existing[0].type).toBe('workflow');
+    });
+
+    it('checkExistingSkills returns existing skill files', () => {
+      const skillDir = path.join(tempDir, '.opencode', 'skill', 'pr-review');
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), 'content');
+
+      const existing = checkExistingSkills({ cwd: tempDir });
+
+      expect(existing).toHaveLength(1);
+      expect(existing[0].name).toBe('pr-review');
+      expect(existing[0].type).toBe('skill');
+    });
+
+    it('checkExistingAuthWorkflow returns existing auth workflow', () => {
+      const workflowDir = path.join(tempDir, '.github', 'workflows');
+      fs.mkdirSync(workflowDir, { recursive: true });
+      fs.writeFileSync(path.join(workflowDir, 'opencode-auth.yml'), 'content');
+
+      const existing = checkExistingAuthWorkflow({ cwd: tempDir });
+
+      expect(existing).not.toBeNull();
+      expect(existing.name).toBe('opencode-auth');
+      expect(existing.type).toBe('auth');
+    });
+
+    it('checkExistingAuthWorkflow returns null when file does not exist', () => {
+      const existing = checkExistingAuthWorkflow({ cwd: tempDir });
+      expect(existing).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add CLI option to override existing workflow files and skills during installation without interactive prompts
- Update installer logic to check for existing files and handle override behavior with safety mechanisms
- Extend CLI interface with new flag and user input handling for override scenarios
- Add comprehensive test coverage for the new override functionality
- Update README with documentation and examples for the new CLI option